### PR TITLE
ASN.1 generalizedTime to Python datetime parser

### DIFF
--- a/rfc3161ng/api.py
+++ b/rfc3161ng/api.py
@@ -1,8 +1,11 @@
 import hashlib
 import requests
 import base64
+import re
+import datetime
+import dateutil.relativedelta
+import pytz
 
-import dateutil.parser
 from pyasn1.codec.der import encoder, decoder
 from pyasn1_modules import rfc2459
 from pyasn1.type import univ
@@ -44,7 +47,34 @@ class TimestampingError(RuntimeError):
     pass
 
 
-def get_timestamp(tst):
+def generalizedtime_to_utc_datetime(gt, naive=True):
+    m = re.match('(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})(?P<hour>\d{2})(?:(?P<minutes>\d{2})(?:(?P<seconds>\d{2})(?:[.,](?P<fractions>\d*))?)?)?(?P<tz>Z|[+-]\d{2}(?:\d{2})?)?', gt)
+    if m:
+        d = m.groupdict()
+        dt = datetime.datetime(
+            int(d['year']),
+            int(d['month']),
+            int(d['day']),
+            int(d['hour']),
+            int(d['minutes'] or 0),
+            int(d['seconds'] or 0),
+            int(float('0.' + d['fractions']) * 1000000 if d['fractions'] else 0)
+        )
+        if d['tz'] and d['tz'][0] in ('+', '-'):
+            diff = dateutil.relativedelta.relativedelta(
+                hours=int(d['tz'][1:3]),
+                minutes=int(d['tz'][3:5]) if len(d['tz']) > 3 else 0
+            )
+            if d['tz'][0] == '+':
+                dt -= diff
+            else:
+                dt += diff
+        return dt if naive else pytz.utc.localize(dt)
+    else:
+        raise ValueError("not an ASN.1 generalizedTime: '%s'" % (gt,))
+
+
+def get_timestamp(tst, naive=True):
     try:
         if not isinstance(tst, rfc3161ng.TimeStampToken):
             tst, substrate = decoder.decode(tst, asn1Spec=rfc3161ng.TimeStampToken())
@@ -59,7 +89,7 @@ def get_timestamp(tst):
         if substrate:
             raise ValueError("extra data after tst")
         genTime = tstinfo.getComponentByName('genTime')
-        return dateutil.parser.parse(str(genTime))
+        return generalizedtime_to_utc_datetime(str(genTime), naive)
     except PyAsn1Error as exc:
         raise ValueError('not a valid TimeStampToken', exc)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import os.path
 import datetime
+import pytz
 
 # from pyasn1.type import univ
 
@@ -63,9 +64,28 @@ def test_teszt_e_szigno_hu_with_nonce():
 
 def test_encode_decode_timestamp_request():
     tsq = rfc3161ng.make_timestamp_request(data="test")
-    assert tsq.prettyPrint() == "TimeStampReq:\n version='v1'\n messageImprint=MessageImprint:\n  hashAlgorithm=AlgorithmIdentifier:\n   algorithm=1.3.14.3.2.26\n\n  hashedMessage=0xa94a8fe5ccb19ba61c4c0873d391e987982fbbd3\n\n certReq='False'\n"
+    assert tsq.prettyPrint() == "TimeStampReq:\n version=v1\n messageImprint=MessageImprint:\n  hashAlgorithm=AlgorithmIdentifier:\n   algorithm=1.3.14.3.2.26\n\n  hashedMessage=0xa94a8fe5ccb19ba61c4c0873d391e987982fbbd3\n\n certReq=False\n"
     bin_tsq = rfc3161ng.encode_timestamp_request(tsq)
     assert bin_tsq == b'0$\x02\x01\x010\x1f0\x07\x06\x05+\x0e\x03\x02\x1a\x04\x14\xa9J\x8f\xe5\xcc\xb1\x9b\xa6\x1cL\x08s\xd3\x91\xe9\x87\x98/\xbb\xd3'
     tsq2 = rfc3161ng.decode_timestamp_request(bin_tsq)
     assert tsq2.getComponentByPosition(1).getComponentByPosition(1) == tsq.getComponentByPosition(1).getComponentByPosition(1)
     # This test is probably still incomplete
+
+
+def test_generalized_time_decoding():
+    tests = [
+        # generalizedTime string, naive, expected datetime
+        ('20180208181004,948468', True, datetime.datetime(2018, 2, 8, 18, 10, 4, 948468)),
+        ('20180208181004', True, datetime.datetime(2018, 2, 8, 18, 10, 4, 0)),
+        ('201802081810', True, datetime.datetime(2018, 2, 8, 18, 10, 0, 0)),
+        ('2018020818', True, datetime.datetime(2018, 2, 8, 18, 0, 0, 0)),
+        ('20180208181004.948468Z', True, datetime.datetime(2018, 2, 8, 18, 10, 4, 948468)),
+        ('20180208181004.948468+01', True, datetime.datetime(2018, 2, 8, 17, 10, 4, 948468)),
+        ('20180208181004.948468-01', True, datetime.datetime(2018, 2, 8, 19, 10, 4, 948468)),
+        ('20180208181004.948468+0130', True, datetime.datetime(2018, 2, 8, 16, 40, 4, 948468)),
+        ('20180208181004.948468+0130', False, pytz.utc.localize(datetime.datetime(2018, 2, 8, 16, 40, 4, 948468))),
+    ]
+    from rfc3161ng.api import generalizedtime_to_utc_datetime
+    for gt, naive, expected in tests:
+        assert generalizedtime_to_utc_datetime(gt, naive) == expected
+


### PR DESCRIPTION
There was a problem when testing against 'https://freetsa.org/tsr': it sent a (correct) ASN.1 generalizedTime string, e.g. '20180208181004.948468Z', which dateutil.parse doesn't understand.

I propose a new function, generalizedtime_to_utc_datetime(), which parses the possible formats of generalizedTime properly and optionally adds timezone information (UTC at this time only). The default is a 'naive' datetime object.

I've also added tests for this function with several possible formats which can be used in generalizedTime ASN.1 objects.